### PR TITLE
chore: migrate Coveralls coverage to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: "Coverage"
 
 on:
   pull_request:
+  workflow_dispatch:
 
   push:
     branches: ["*"]
@@ -12,7 +13,7 @@ on:
 jobs:
   coverage:
     name: "Nette Tester"
-    uses: contributte/.github/.github/workflows/nette-tester-coverage.yml@v1
+    uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
     with:
       php: "8.4"
       make: "init coverage"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/nella-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/nella-skeleton/master"></a>
-  <a href="https://coveralls.io/r/contributte/nella-skeleton"><img src="https://badgen.net/coveralls/c/github/contributte/nella-skeleton"></a>
+  <a href="https://codecov.io/gh/contributte/nella-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/nella-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/nella-skeleton"><img src="https://badgen.net/packagist/dm/contributte/nella-skeleton"></a>
   <a href="https://packagist.org/packages/contributte/nella-skeleton"><img src="https://badgen.net/packagist/v/contributte/nella-skeleton"></a>
 </p>

--- a/tests/.coveralls.yml
+++ b/tests/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: github-actions
-coverage_clover: coverage.xml
-json_path: coverage.json


### PR DESCRIPTION
## What changed
- replaced the README coverage badge with the Codecov badge
- switched the coverage workflow to the shared `nette-tester-coverage-v2` workflow and added manual dispatch support
- removed the obsolete `tests/.coveralls.yml` file

## Why
- finishes the remaining Coveralls-to-Codecov migration for this repository
- aligns `contributte/nella-skeleton` with the newer coverage setup used in other Contributte packages

Refs contributte/contributte#72