### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary

Replace the `coverage` Makefile target to run Tester with `php` instead of `phpdbg`.

## Motivation

Issue #73 tracks removing `phpdbg` from Contributte coverage targets so coverage can run through the standard PHP binary.

## Changes

- update `Makefile` coverage target from `-p phpdbg` to `-p php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification

Manual verification notes:
- `make coverage` now runs `vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests`
- local coverage execution is blocked in this environment because PHP has no Xdebug or PCOV extension loaded, and the process is no longer using the PHPDBG SAPI

Relates to contributte/contributte#73