### PR TITLE
Docs: unify skeleton README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Website ðŸš€ <a href="https://contributte.org">contributte.org</a> | Contact ðŸ‘
 
 ## Goal
 
-Main goal is to show how [contributte/nella](https://github.com/contributte/sentry) can boost your [Nette](https://nette.org) based project..
+This skeleton demonstrates how [contributte/nella](https://github.com/contributte/nella) can be used in a [Nette](https://nette.org)-based project.
 
 ## Demo
 
@@ -40,9 +40,12 @@ Create project using composer.
 
 ```bash
 composer create-project -s dev contributte/nella-skeleton acme
+cd acme
+make init
+make project
 ```
 
-Now you have application installed. It's time to run it.
+`make init` creates `config/local.neon` from the local configuration template. Keep machine-specific parameters and service definitions there.
 
 ## Startup
 
@@ -53,7 +56,20 @@ make dev
 # php -S 0.0.0.0:8000 -t www
 ```
 
-Then visit [http://localhost:8000](http://localhost:8000) in your browser.
+Then visit [http://localhost:8000](http://localhost:8000) in your browser. This repository does not include a Docker Compose definition; use the built-in server above for the bundled local setup.
+
+## Commands
+
+```bash
+make qa       # coding standard and static analysis
+make tests    # run Tester tests
+make csf      # fix coding style
+make clean    # remove temporary files and logs
+```
+
+## Configuration
+
+The shared Nette configuration is `config/config.neon`; local overrides belong in the ignored `config/local.neon` created by `make init`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-![](https://heatbadger.now.sh/github/readme/contributte/nella-skeleton/)
+# Nella Skeleton
+
+![Nella Skeleton activity](https://heatbadger.now.sh/github/readme/contributte/nella-skeleton/)
 
 <p align=center>
-  <a href="https://github.com/contributte/nella-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/nella-skeleton/master"></a>
-  <a href="https://codecov.io/gh/contributte/nella-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/nella-skeleton"></a>
-  <a href="https://packagist.org/packages/contributte/nella-skeleton"><img src="https://badgen.net/packagist/dm/contributte/nella-skeleton"></a>
-  <a href="https://packagist.org/packages/contributte/nella-skeleton"><img src="https://badgen.net/packagist/v/contributte/nella-skeleton"></a>
+  <a href="https://github.com/contributte/nella-skeleton/actions"><img alt="Build status" src="https://badgen.net/github/checks/contributte/nella-skeleton/master"></a>
+  <a href="https://codecov.io/gh/contributte/nella-skeleton"><img alt="Code coverage" src="https://badgen.net/codecov/c/github/contributte/nella-skeleton"></a>
+  <a href="https://packagist.org/packages/contributte/nella-skeleton"><img alt="Packagist downloads" src="https://badgen.net/packagist/dm/contributte/nella-skeleton"></a>
+  <a href="https://packagist.org/packages/contributte/nella-skeleton"><img alt="Packagist version" src="https://badgen.net/packagist/v/contributte/nella-skeleton"></a>
 </p>
 <p align=center>
-  <a href="https://packagist.org/packages/contributte/nella-skeleton"><img src="https://badgen.net/packagist/php/contributte/nella-skeleton"></a>
-  <a href="https://github.com/contributte/nella-skeleton"><img src="https://badgen.net/github/license/contributte/nella-skeleton"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
-  <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
+  <a href="https://packagist.org/packages/contributte/nella-skeleton"><img alt="Supported PHP version" src="https://badgen.net/packagist/php/contributte/nella-skeleton"></a>
+  <a href="https://github.com/contributte/nella-skeleton"><img alt="License" src="https://badgen.net/github/license/contributte/nella-skeleton"></a>
+  <a href="https://bit.ly/ctteg"><img alt="Gitter support" src="https://badgen.net/badge/support/gitter/cyan"></a>
+  <a href="https://bit.ly/cttfo"><img alt="Forum support" src="https://badgen.net/badge/support/forum/yellow"></a>
+  <a href="https://contributte.org/partners.html"><img alt="Sponsor Contributte" src="https://badgen.net/badge/sponsor/donations/F96854"></a>
 </p>
 
 <p align=center>
@@ -19,7 +21,7 @@ Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact �
 </p>
 
 <p align=center>
-	<img src="https://api.microlink.io?url=https%3A%2F%2Fexamples.contributte.org%2Fnella-skeleton%2F&overlay.browser=light&screenshot=true&meta=false&embed=screenshot.url"></img>
+	<img alt="Nella Skeleton demo" src="https://api.microlink.io?url=https%3A%2F%2Fexamples.contributte.org%2Fnella-skeleton%2F&overlay.browser=light&screenshot=true&meta=false&embed=screenshot.url"></img>
 </p>
 
 -----
@@ -32,7 +34,7 @@ This skeleton demonstrates how [contributte/nella](https://github.com/contributt
 
 https://examples.contributte.org/nella-skeleton/
 
-## Installation
+## Web quick start
 
 You will need `PHP 8.4+` and [Composer](https://getcomposer.org/).
 
@@ -42,14 +44,10 @@ Create project using composer.
 composer create-project -s dev contributte/nella-skeleton acme
 cd acme
 make init
-make project
+make setup
 ```
 
-`make init` creates `config/local.neon` from the local configuration template. Keep machine-specific parameters and service definitions there.
-
-## Startup
-
-The easiest way is to use php built-in web server.
+Composer installs the dependencies. `make init` creates `config/local.neon` from the local configuration template, and `make setup` prepares writable runtime directories.
 
 ```bash
 make dev
@@ -57,6 +55,13 @@ make dev
 ```
 
 Then visit [http://localhost:8000](http://localhost:8000) in your browser. This repository does not include a Docker Compose definition; use the built-in server above for the bundled local setup.
+
+To verify the exact bundled page from another terminal:
+
+```bash
+curl -s http://localhost:8000 | grep -F 'Hello!'
+# 	Hello!
+```
 
 ## Commands
 
@@ -78,7 +83,7 @@ See [how to contribute](https://contributte.org/contributing.html) to this packa
 This package is currently maintaining by these authors.
 
 <a href="https://github.com/f3l1x">
-    <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
+    <img alt="Milan Šulc" width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
 </a>
 
 -----


### PR DESCRIPTION
## Scope

- Add a Nella web quick start using `make init` and `make setup`, without redundant `make project`.
- Document an exact, source-backed `Hello!` first-success proof.
- Preserve badges, demo media, and links with accessible labels.

## Checks

- Temporary-copy smoke: `make init`, `make setup`, and the default page contained exact `Hello!`.
- Central skeleton README evaluator: 7 passed, 0 failed, 7 semantic items unassessed.
- `git diff --check` passed; commit changes only `README.md`.